### PR TITLE
Fix file picker filters

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1069,7 +1069,7 @@ static void randomize() {
 
 static void export_exe(bool patch_renderdoc) {
     std::string path;
-    auto result = NFD::SaveDialog({ { "Game", {".exe"} } }, std::filesystem::current_path().string().c_str(), path, window);
+    auto result = NFD::SaveDialog({ { "Game", {"exe"} } }, std::filesystem::current_path().string().c_str(), path, window);
 
     if(result == NFD::Result::Error) {
         ErrorDialog.push(NFD::GetError());
@@ -1219,7 +1219,7 @@ ImGuiID DockSpaceOverViewport() {
             }
             if(ImGui::MenuItem("Export Map")) {
                 std::string path;
-                auto result = NFD::SaveDialog({ { "Map", {".map" }} }, std::filesystem::current_path().string().c_str(), path, window);
+                auto result = NFD::SaveDialog({ { "Map", {"map" }} }, std::filesystem::current_path().string().c_str(), path, window);
 
                 if(result == NFD::Result::Error) {
                     ErrorDialog.push(NFD::GetError());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -596,7 +596,7 @@ static bool load_game(const std::string& path) {
 
 static void load_game_dialog() {
     std::string path;
-    auto result = NFD::OpenDialog({ { "Game", { ".exe" } } }, "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Animal Well", path, window);
+    auto result = NFD::OpenDialog({ { "Game", { "exe" } } }, "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Animal Well", path, window);
     if(result == NFD::Result::Error) {
         ErrorDialog.push(NFD::GetError());
     } else if(result == NFD::Result::Okay) {
@@ -1197,7 +1197,7 @@ ImGuiID DockSpaceOverViewport() {
 
             if(ImGui::MenuItem("Load Map")) {
                 std::string path;
-                auto result = NFD::OpenDialog({ {"Map", {".map"}} }, std::filesystem::current_path().string().c_str(), path, window);
+                auto result = NFD::OpenDialog({ {"Map", {"map"}} }, std::filesystem::current_path().string().c_str(), path, window);
 
                 if(result == NFD::Result::Error) {
                     ErrorDialog.push(NFD::GetError());


### PR DESCRIPTION
The file picker filters don't actually work (at least on my machine) unless the dots before the paths are removed. It's how they do it in [their example](https://github.com/btzy/nativefiledialog-extended?tab=readme-ov-file#file-filter-syntax) so it's probably supposed to be like this.