### PR TITLE
Fix a compilation error on Arch Linux

### DIFF
--- a/src/image.hpp
+++ b/src/image.hpp
@@ -4,6 +4,7 @@
 #include <span>
 #include <string>
 #include <utility>
+#include <cstdint>
 
 class Image {
     uint32_t* data_ = nullptr;


### PR DESCRIPTION
This fixes #11 -- not sure what exactly is the difference between Ubuntu's toolchain and Arch's current chain, but clearly there's some subtle difference which requires this.  Otherwise the compilation errors out about not understanding `uint32_t`.